### PR TITLE
Stop unrestricted looping.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -148,6 +148,10 @@ int main(void)
     strftime(buf, sizeof(buf) - 1, "%Y %b %d %H:%M", timeinfo);
     set_field_buffer(qsoform->field[QSOF_TIMESTAMP], 0, buf);
 
+    /* Refresh UI. */
+    update_panels();
+    doupdate();
+
     if (ch == ERR) {
       napms(25);
       continue;
@@ -198,9 +202,6 @@ int main(void)
       break;
     }
 
-    /* Refresh UI. */
-    update_panels();
-    doupdate();
   }
 
  quit:


### PR DESCRIPTION
Since `getch` is non-blocking it means that while no interaction is happening, the loop is nooping unconstrained - consuming 100% cpu. Add `napms` call when no input has been received, which makes the loop sleep for 25ms. This reduces cpu load to ~0-1% and is not impairing responsiveness.