### PR TITLE
Refactor messy qso form code into separate component.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,3 @@
 bin_PROGRAMS = lylog
-lylog_SOURCES = main.c
+lylog_SOURCES = main.c qsoform.c
 lylog_LDADD = -lncurses -lform -lpanel

--- a/src/main.c
+++ b/src/main.c
@@ -7,129 +7,16 @@
 #include <panel.h>
 
 #include "config.h"
-
-
-/**
- * QSO FORM
- *
- * Handles the QSO input form.
- */
-
-
-typedef enum {
-  QSOF_TIMESTAMP,
-  QSOF_MODE,
-  QSOF_BAND,
-  QSOF_CALLSIGN,
-  QSOF_RSTSENT,
-  QSOF_RSTRCVD,
-  QSOF_MAX,
-} qsoform_field_t;
-
-
-typedef struct {
-  FIELD *field[QSOF_MAX + 1];
-  FORM *form;
-  WINDOW *win;
-  PANEL *panel;
-} qsoform_t;
-
-
-qsoform_t *new_qsoform() {
-  qsoform_t *obj = (qsoform_t *)malloc(sizeof(qsoform_t));
-  int cols, rows;
-
-  obj->field[QSOF_TIMESTAMP] = new_field(1, 17, 1, 1, 0, 0);
-  set_field_back(obj->field[QSOF_TIMESTAMP], COLOR_PAIR(1));
-  set_field_fore(obj->field[QSOF_TIMESTAMP], COLOR_PAIR(1));
-  field_opts_off(obj->field[QSOF_TIMESTAMP], O_AUTOSKIP | O_ACTIVE | O_EDIT);
-
-  obj->field[QSOF_MODE] = new_field(1, 5, 1, 20, 0, 0);
-  set_field_back(obj->field[QSOF_MODE], COLOR_PAIR(1));
-  set_field_fore(obj->field[QSOF_MODE], COLOR_PAIR(1));
-  field_opts_off(obj->field[QSOF_MODE], O_AUTOSKIP | O_ACTIVE | O_EDIT);
-  set_field_buffer(obj->field[QSOF_MODE], 0, "CW");
-
-  obj->field[QSOF_BAND] = new_field(1, 8, 1, 26, 0, 0);
-  set_field_back(obj->field[QSOF_BAND], COLOR_PAIR(1));
-  set_field_fore(obj->field[QSOF_BAND], COLOR_PAIR(1));
-  field_opts_off(obj->field[QSOF_BAND], O_AUTOSKIP | O_ACTIVE | O_EDIT);
-  set_field_buffer(obj->field[QSOF_BAND], 0, "40M");
-
-  obj->field[QSOF_CALLSIGN] = new_field(1, 10, 1, 35, 0, 0);
-  set_field_back(obj->field[QSOF_CALLSIGN], A_UNDERLINE);
-  field_opts_off(obj->field[QSOF_CALLSIGN], O_AUTOSKIP);
-
-  obj->field[QSOF_RSTSENT] = new_field(1, 4, 1, 46, 0, 0);
-  set_field_back(obj->field[QSOF_RSTSENT], A_UNDERLINE);
-  field_opts_off(obj->field[QSOF_RSTSENT], O_AUTOSKIP);
-
-  obj->field[QSOF_RSTRCVD] = new_field(1, 4, 1, 51, 0, 0);
-  set_field_back(obj->field[QSOF_RSTRCVD], A_UNDERLINE);
-  field_opts_off(obj->field[QSOF_RSTRCVD], O_AUTOSKIP);
-
-  obj->field[QSOF_MAX] = NULL;
-
-  obj->form = new_form(obj->field);
-
-  scale_form(obj->form, &rows, &cols);
-
-  obj->win = newwin(rows + 2, COLS, 20, 0);
-  keypad(obj->win, TRUE);
-
-  obj->panel = new_panel(obj->win);
-
-  set_form_win(obj->form, obj->win);
-  set_form_sub(obj->form, derwin(obj->win, rows, cols + 1, 1, 1));
-
-  box(obj->win, 0, 0);
-
-  post_form(obj->form);
-
-  wattron(obj->win, COLOR_PAIR(2) | A_BOLD);
-  mvwprintw(obj->win, 1, 2, "Date");
-  mvwprintw(obj->win, 1, 14, "Time");
-  mvwprintw(obj->win, 1, 21, "Mode");
-  mvwprintw(obj->win, 1, 27, "Band");
-  mvwprintw(obj->win, 1, 36, "Callsign");
-  mvwprintw(obj->win, 1, 47, "Sent");
-  mvwprintw(obj->win, 1, 52, "Rcvd");
-  wattroff(obj->win, COLOR_PAIR(2) | A_BOLD);
-
-  return obj;
-}
-
-
-void free_qsoform(qsoform_t *obj) {
-  unpost_form(obj->form);
-
-  del_panel(obj->panel);
-
-  delwin(obj->win);
-
-  free_form(obj->form);
-
-  free_field(obj->field[QSOF_TIMESTAMP]);
-  free_field(obj->field[QSOF_MODE]);
-  free_field(obj->field[QSOF_BAND]);
-  free_field(obj->field[QSOF_CALLSIGN]);
-  free_field(obj->field[QSOF_RSTSENT]);
-  free_field(obj->field[QSOF_RSTRCVD]);
-
-  free(obj);
-}
+#include "qsoform.h"
 
 
 int main(void)
 {
+  qsoFormComponent *qso_form;
   PANEL *panel;
   WINDOW *win, *pad;
-  qsoform_t *qsoform;
   int ch;
-  char buf[24] = {0};
   char qsolist[2048] = {0};
-  time_t rawtime;
-  struct tm *timeinfo;
 
   /* Initialize ncurses. */
   initscr();
@@ -139,11 +26,8 @@ int main(void)
   keypad(stdscr, TRUE);
   nodelay(stdscr, TRUE);
 
-  init_pair(1, COLOR_WHITE, COLOR_BLACK);
-  init_pair(2, COLOR_RED, COLOR_BLACK);
-  //bkgd(COLOR_PAIR(1));
-
-  qsoform = new_qsoform();
+  qso_form = newQsoFormComponent();
+  initQsoFormComponent(qso_form);
 
   win = newwin(20, COLS, 0, 0);
   keypad(win, TRUE);
@@ -155,14 +39,9 @@ int main(void)
   while (1) {
     ch = getch();
 
-    time(&rawtime);
-    timeinfo = localtime(&rawtime);
-    strftime(buf, sizeof(buf) - 1, "%Y %b %d %H:%M", timeinfo);
-    set_field_buffer(qsoform->field[QSOF_TIMESTAMP], 0, buf);
-
-    mvwaddstr(pad, 0, 0, qsolist);
-
     /* Refresh UI. */
+    refreshQsoFormComponent(qso_form);
+    mvwprintw(pad, 0, 0, qsolist);
     update_panels();
     doupdate();
     prefresh(pad, 0, 0, 1, 1, 18, COLS - 2);
@@ -176,53 +55,40 @@ int main(void)
     case KEY_F(1):
       goto quit;
       break;
-    case KEY_RIGHT:
-    case '\t':
-      form_driver(qsoform->form, REQ_NEXT_FIELD);
-      form_driver(qsoform->form, REQ_END_LINE);
-      break;
-    case KEY_LEFT:
-      form_driver(qsoform->form, REQ_PREV_FIELD);
-      form_driver(qsoform->form, REQ_END_LINE);
-      break;
-    case KEY_BACKSPACE:
-      form_driver(qsoform->form, REQ_DEL_PREV);
-      form_driver(qsoform->form, REQ_END_LINE);
-      break;
     case 10:
-      form_driver(qsoform->form, REQ_VALIDATION);
+      form_driver(qso_form->form, REQ_VALIDATION);
       sprintf(qsolist,
               "%s%s %s%s%s%s%s\n",
               qsolist,
-              field_buffer(qsoform->field[QSOF_TIMESTAMP], 0),
-              field_buffer(qsoform->field[QSOF_MODE], 0),
-              field_buffer(qsoform->field[QSOF_BAND], 0),
-              field_buffer(qsoform->field[QSOF_CALLSIGN], 0),
-              field_buffer(qsoform->field[QSOF_RSTSENT], 0),
-              field_buffer(qsoform->field[QSOF_RSTRCVD], 0));
+              field_buffer(qso_form->field[QFFT_TIMESTAMP], 0),
+              field_buffer(qso_form->field[QFFT_MODE], 0),
+              field_buffer(qso_form->field[QFFT_BAND], 0),
+              field_buffer(qso_form->field[QFFT_CALLSIGN], 0),
+              field_buffer(qso_form->field[QFFT_RSTSENT], 0),
+              field_buffer(qso_form->field[QFFT_RSTRCVD], 0));
 
-      form_driver(qsoform->form, REQ_LAST_FIELD);
-      form_driver(qsoform->form, REQ_CLR_FIELD);
-      form_driver(qsoform->form, REQ_PREV_FIELD);
-      form_driver(qsoform->form, REQ_CLR_FIELD);
-      form_driver(qsoform->form, REQ_PREV_FIELD);
-      form_driver(qsoform->form, REQ_CLR_FIELD);
-      form_driver(qsoform->form, REQ_PREV_FIELD);
-      form_driver(qsoform->form, REQ_CLR_FIELD);
-      form_driver(qsoform->form, REQ_PREV_FIELD);
-      form_driver(qsoform->form, REQ_CLR_FIELD);
-      form_driver(qsoform->form, REQ_PREV_FIELD);
-      form_driver(qsoform->form, REQ_CLR_FIELD);
+      form_driver(qso_form->form, REQ_LAST_FIELD);
+      form_driver(qso_form->form, REQ_CLR_FIELD);
+      form_driver(qso_form->form, REQ_PREV_FIELD);
+      form_driver(qso_form->form, REQ_CLR_FIELD);
+      form_driver(qso_form->form, REQ_PREV_FIELD);
+      form_driver(qso_form->form, REQ_CLR_FIELD);
+      form_driver(qso_form->form, REQ_PREV_FIELD);
+      form_driver(qso_form->form, REQ_CLR_FIELD);
+      form_driver(qso_form->form, REQ_PREV_FIELD);
+      form_driver(qso_form->form, REQ_CLR_FIELD);
+      form_driver(qso_form->form, REQ_PREV_FIELD);
+      form_driver(qso_form->form, REQ_CLR_FIELD);
       break;
     default:
-      form_driver(qsoform->form, ch);
+      processQsoFormComponentInput(qso_form, ch);
       break;
     }
 
   }
 
  quit:
-  free_qsoform(qsoform);
+  freeQsoFormComponent(qso_form);
 
   endwin();
 

--- a/src/qsoform.c
+++ b/src/qsoform.c
@@ -1,0 +1,178 @@
+#include <stdlib.h>
+#include <time.h>
+
+#include <form.h>
+#include <panel.h>
+
+#include "config.h"
+#include "qsoform.h"
+
+
+qsoFormField qsoFormFieldDesc[QFFT_MAX] = {
+  {
+    .type_id = QFFT_TIMESTAMP,
+    .label = "Date        Time",
+    .width = 17,
+    .height = 1,
+    .top = 1,
+    .left = 1,
+    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .options = O_PUBLIC | O_STATIC | O_VISIBLE,
+  },
+  {
+    .type_id = QFFT_MODE,
+    .label = "Mode",
+    .width = 5,
+    .height = 1,
+    .top = 1,
+    .left = 20,
+    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .options = O_PUBLIC | O_STATIC | O_VISIBLE,
+  },
+  {
+    .type_id = QFFT_BAND,
+    .label = "Band",
+    .width = 8,
+    .height = 1,
+    .top = 1,
+    .left = 26,
+    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .options = O_PUBLIC | O_STATIC | O_VISIBLE,
+  },
+  {
+    .type_id = QFFT_CALLSIGN,
+    .label = "Callsign",
+    .width = 10,
+    .height = 1,
+    .top = 1,
+    .left = 35,
+    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .options = O_PUBLIC | O_STATIC | O_VISIBLE | O_EDIT | O_ACTIVE,
+  },
+  {
+    .type_id = QFFT_RSTSENT,
+    .label = "RSTs",
+    .width = 4,
+    .height = 1,
+    .top = 1,
+    .left = 46,
+    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .options = O_PUBLIC | O_STATIC | O_VISIBLE | O_EDIT | O_ACTIVE,
+  },
+  {
+    .type_id = QFFT_RSTRCVD,
+    .label = "RSTr",
+    .width = 4,
+    .height = 1,
+    .top = 1,
+    .left = 51,
+    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .options = O_PUBLIC | O_STATIC | O_VISIBLE | O_EDIT | O_ACTIVE,
+  },
+};
+
+
+qsoFormComponent *newQsoFormComponent(void) {
+  return (qsoFormComponent *)malloc(sizeof(qsoFormComponent));
+}
+
+
+void initQsoFormComponent(qsoFormComponent *co) {
+  int cols, rows, ii;
+
+  init_pair(QSOFORMPANEL_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
+
+  for (ii = 0; ii < QFFT_MAX; ii++) {
+    co->field[ii] = new_field(qsoFormFieldDesc[ii].height,
+                                 qsoFormFieldDesc[ii].width,
+                                 qsoFormFieldDesc[ii].top,
+                                 qsoFormFieldDesc[ii].left,
+                                 0, 0);
+    set_field_opts(co->field[ii], qsoFormFieldDesc[ii].options);
+    set_field_back(co->field[ii], qsoFormFieldDesc[ii].bgcolor);
+    set_field_fore(co->field[ii], qsoFormFieldDesc[ii].fgcolor);
+  }
+
+  co->field[QFFT_MAX] = NULL;
+
+  co->form = new_form(co->field);
+
+  scale_form(co->form, &rows, &cols);
+
+  co->window = newwin(rows + 2, COLS, 20, 0);
+  keypad(co->window, TRUE);
+
+  box(co->window, 0, 0);
+
+  co->panel = new_panel(co->window);
+
+  set_form_win(co->form, co->window);
+  set_form_sub(co->form, derwin(co->window, rows, cols + 1, 1, 1));
+
+  post_form(co->form);
+
+  wattron(co->window, COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR) | A_BOLD);
+  for (ii = 0; ii < QFFT_MAX; ii++) {
+    mvwprintw(co->window, 1, qsoFormFieldDesc[ii].left + 1, qsoFormFieldDesc[ii].label);
+  }
+  wattroff(co->window, COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR) | A_BOLD);
+}
+
+
+void refreshQsoFormComponent(qsoFormComponent *co) {
+  time_t rawtime;
+  struct tm *timeinfo;
+  char timestr[32] = { 0 };
+
+  time(&rawtime);
+  timeinfo = localtime(&rawtime);
+  strftime(timestr, sizeof(timestr) - 1, "%Y %b %d %H:%M", timeinfo);
+  set_field_buffer(co->field[QFFT_TIMESTAMP], 0, timestr);
+}
+
+
+void processQsoFormComponentInput(qsoFormComponent *co, int ch) {
+  switch (ch) {
+    case KEY_RIGHT:
+    case '\t':
+      form_driver(co->form, REQ_NEXT_FIELD);
+      form_driver(co->form, REQ_END_LINE);
+      break;
+    case KEY_LEFT:
+      form_driver(co->form, REQ_PREV_FIELD);
+      form_driver(co->form, REQ_END_LINE);
+      break;
+    case KEY_BACKSPACE:
+      form_driver(co->form, REQ_DEL_PREV);
+      form_driver(co->form, REQ_END_LINE);
+      break;
+    default:
+      form_driver(co->form, ch);
+      break;
+  }
+}
+
+
+void freeQsoFormComponent(qsoFormComponent *co) {
+  int ii;
+
+  unpost_form(co->form);
+
+  del_panel(co->panel);
+
+  delwin(co->window);
+
+  free_form(co->form);
+
+  for (ii = 0; ii < QFFT_MAX; ii++) {
+    free_field(co->field[ii]);
+  }
+
+  free(co);
+}

--- a/src/qsoform.h
+++ b/src/qsoform.h
@@ -1,0 +1,49 @@
+#ifndef __qsoform_h__
+#define __qsoform_h__
+
+#define QSOFORMPANEL_COLOR_PAIR 1
+
+
+typedef enum qsoFormFieldType_e {
+  QFFT_TIMESTAMP,
+  QFFT_MODE,
+  QFFT_BAND,
+  QFFT_CALLSIGN,
+  QFFT_RSTSENT,
+  QFFT_RSTRCVD,
+  QFFT_MAX,
+} qsoFormFieldType;
+
+
+typedef struct qsoFormField_s {
+  qsoFormFieldType  type_id;
+  const char       *label;
+  int             width;
+  int             height;
+  int             top;
+  int             left;
+  chtype            bgcolor;
+  chtype            fgcolor;
+  Field_Options     options;
+} qsoFormField;
+
+
+typedef struct qsoForm_s {
+  FIELD  *field[QFFT_MAX + 1];
+  FORM   *form;
+  WINDOW *window;
+  PANEL  *panel;
+} qsoFormComponent;
+
+
+extern qsoFormField qsoFormFieldDesc[QFFT_MAX];
+
+
+qsoFormComponent *newQsoFormComponent(void);
+void initQsoFormComponent(qsoFormComponent *co);
+void refreshQsoFormComponent(qsoFormComponent *co);
+void processQsoFormComponentInput(qsoFormComponent *co, int ch);
+void freeQsoFormComponent(qsoFormComponent *co);
+
+
+#endif // __qsoform_h__


### PR DESCRIPTION
Part of #1 

This adds some structure to the qso form code and introduces some potential code style rules:
- things on screen will be called _components_
- components will live in their own files
- structures, enums will be named using lower camel case (e.g. `qsoFormComponent`)
- main structure holding the state of the component will be named accordingly (`fooBarComponent`)
- all components should have at least
  - `newFooBarComponent` that allocates memory for the component
  - `initFooBarComponent` that initializes the component
  - `freeFooBarComponent` that denitializes and frees up the memory held by component
- additional functions for component
  - `refreshFooBarComponent` - called just before the ncurses refresh/update.
  - `processFooBarComponentInput` - process input.