### PR TITLE
Refactor messy qso list code into qsoListComponent

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,3 @@
 bin_PROGRAMS = lylog
-lylog_SOURCES = main.c qsoform.c
+lylog_SOURCES = main.c qsoform.c qsolist.c
 lylog_LDADD = -lncurses -lform -lpanel

--- a/src/main.c
+++ b/src/main.c
@@ -8,43 +8,46 @@
 
 #include "config.h"
 #include "qsoform.h"
+#include "qsolist.h"
 
 
-int main(void)
-{
-  qsoFormComponent *qso_form;
-  PANEL *panel;
-  WINDOW *win, *pad;
-  int ch;
-  char qsolist[2048] = {0};
-
-  /* Initialize ncurses. */
+void initializeNcurses(void) {
   initscr();
   start_color();
   cbreak();
   noecho();
   keypad(stdscr, TRUE);
   nodelay(stdscr, TRUE);
+}
+
+
+void refreshNcurses(void) {
+  update_panels();
+  doupdate();
+}
+
+
+int main(void)
+{
+  qsoFormComponent *qso_form;
+  qsoListComponent *qso_list;
+  int ch;
+
+  initializeNcurses();
 
   qso_form = newQsoFormComponent();
   initQsoFormComponent(qso_form);
 
-  win = newwin(20, COLS, 0, 0);
-  keypad(win, TRUE);
-  panel = new_panel(win);
-  box(win, 0, 0);
-  pad = newpad(18, COLS - 2);
-  touchwin(win);
+  qso_list = newQsoListComponent();
+  initQsoListComponent(qso_list);
 
   while (1) {
     ch = getch();
 
     /* Refresh UI. */
     refreshQsoFormComponent(qso_form);
-    mvwprintw(pad, 0, 0, qsolist);
-    update_panels();
-    doupdate();
-    prefresh(pad, 0, 0, 1, 1, 18, COLS - 2);
+    refreshQsoListComponent(qso_list);
+    refreshNcurses();
 
     if (ch == ERR) {
       napms(25);
@@ -56,10 +59,11 @@ int main(void)
       goto quit;
       break;
     case 10:
+      // TODO(JS): this should eventually go to the respective forms
       form_driver(qso_form->form, REQ_VALIDATION);
-      sprintf(qsolist,
+      sprintf(qso_list->buffer,
               "%s%s %s%s%s%s%s\n",
-              qsolist,
+              qso_list->buffer,
               field_buffer(qso_form->field[QFFT_TIMESTAMP], 0),
               field_buffer(qso_form->field[QFFT_MODE], 0),
               field_buffer(qso_form->field[QFFT_BAND], 0),

--- a/src/qsolist.c
+++ b/src/qsolist.c
@@ -1,0 +1,43 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include <panel.h>
+
+#include "config.h"
+#include "qsolist.h"
+
+
+qsoListComponent *newQsoListComponent(void) {
+  qsoListComponent *co = (qsoListComponent *)malloc(sizeof(qsoListComponent));
+  memset((void *)co->buffer, 0, 2048);
+
+  return co;
+}
+
+
+void initQsoListComponent(qsoListComponent *co) {
+  co->window = newwin(20, COLS, 0, 0);
+  keypad(co->window, TRUE);
+
+  co->panel = new_panel(co->window);
+  box(co->window, 0, 0);
+  co->pad = newpad(18, COLS - 2);
+  touchwin(co->window);
+}
+
+
+void refreshQsoListComponent(qsoListComponent *co) {
+  mvwprintw(co->pad, 0, 0, co->buffer);
+  prefresh(co->pad, 0, 0, 1, 1, 18, COLS - 2);
+}
+
+
+void freeQsoListComponent(qsoListComponent *co) {
+  delwin(co->pad);
+
+  del_panel(co->panel);
+
+  delwin(co->window);
+
+  free(co);
+}

--- a/src/qsolist.h
+++ b/src/qsolist.h
@@ -1,0 +1,21 @@
+#ifndef __qsolist_h__
+#define __qsolist_h__
+
+#define QSOFORMPANEL_COLOR_PAIR 1
+
+
+typedef struct qsoListComponent_s {
+  PANEL  *panel;
+  WINDOW *window;
+  WINDOW *pad;
+  char    buffer[2048];
+} qsoListComponent;
+
+
+qsoListComponent *newQsoListComponent(void);
+void initQsoListComponent(qsoListComponent *co);
+void refreshQsoListComponent(qsoListComponent *co);
+void freeQsoListComponent(qsoListComponent *co);
+
+
+#endif // __qsolist_h__


### PR DESCRIPTION
Part of #1 

Following up on #15 convert qso list code into a separate component.

This leaves only handling of new qso submission in `main` - it requires interaction between `qsoFormComponent` and `qsoListComponent`. I do not yet have a solution to this problem, so leaving it there, but it should be solved soon.