### PR TITLE
Free qsoListComponent memory

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -93,6 +93,7 @@ int main(void)
 
  quit:
   freeQsoFormComponent(qso_form);
+  freeQsoListComponent(qso_list);
 
   endwin();
 


### PR DESCRIPTION
Forgot in #15 and #16 this frees up memory allocated for `qsoListComponent`.