### PR TITLE
Refactor adding to qso list into action

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -27,10 +27,13 @@ void refreshNcurses(void) {
 }
 
 
+void uninitializeNcurses(void) {
+  endwin();
+}
+
+
 int main(void)
 {
-  qsoFormComponent *qso_form;
-  qsoListComponent *qso_list;
   int ch;
 
   initializeNcurses();
@@ -58,32 +61,6 @@ int main(void)
     case KEY_F(1):
       goto quit;
       break;
-    case 10:
-      // TODO(JS): this should eventually go to the respective forms
-      form_driver(qso_form->form, REQ_VALIDATION);
-      sprintf(qso_list->buffer,
-              "%s%s %s%s%s%s%s\n",
-              qso_list->buffer,
-              field_buffer(qso_form->field[QFFT_TIMESTAMP], 0),
-              field_buffer(qso_form->field[QFFT_MODE], 0),
-              field_buffer(qso_form->field[QFFT_BAND], 0),
-              field_buffer(qso_form->field[QFFT_CALLSIGN], 0),
-              field_buffer(qso_form->field[QFFT_RSTSENT], 0),
-              field_buffer(qso_form->field[QFFT_RSTRCVD], 0));
-
-      form_driver(qso_form->form, REQ_LAST_FIELD);
-      form_driver(qso_form->form, REQ_CLR_FIELD);
-      form_driver(qso_form->form, REQ_PREV_FIELD);
-      form_driver(qso_form->form, REQ_CLR_FIELD);
-      form_driver(qso_form->form, REQ_PREV_FIELD);
-      form_driver(qso_form->form, REQ_CLR_FIELD);
-      form_driver(qso_form->form, REQ_PREV_FIELD);
-      form_driver(qso_form->form, REQ_CLR_FIELD);
-      form_driver(qso_form->form, REQ_PREV_FIELD);
-      form_driver(qso_form->form, REQ_CLR_FIELD);
-      form_driver(qso_form->form, REQ_PREV_FIELD);
-      form_driver(qso_form->form, REQ_CLR_FIELD);
-      break;
     default:
       processQsoFormComponentInput(qso_form, ch);
       break;
@@ -95,7 +72,7 @@ int main(void)
   freeQsoFormComponent(qso_form);
   freeQsoListComponent(qso_list);
 
-  endwin();
+  uninitializeNcurses();
 
   return 0;
 }

--- a/src/qsoform.c
+++ b/src/qsoform.c
@@ -6,9 +6,10 @@
 
 #include "config.h"
 #include "qsoform.h"
+#include "qsolist.h"
 
 
-qsoFormField qsoFormFieldDesc[QFFT_MAX] = {
+qsoFormField qso_form_field[QFFT_MAX] = {
   {
     .type_id = QFFT_TIMESTAMP,
     .label = "Date        Time",
@@ -78,6 +79,9 @@ qsoFormField qsoFormFieldDesc[QFFT_MAX] = {
 };
 
 
+qsoFormComponent *qso_form;
+
+
 qsoFormComponent *newQsoFormComponent(void) {
   return (qsoFormComponent *)malloc(sizeof(qsoFormComponent));
 }
@@ -89,14 +93,14 @@ void initQsoFormComponent(qsoFormComponent *co) {
   init_pair(QSOFORMPANEL_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
 
   for (ii = 0; ii < QFFT_MAX; ii++) {
-    co->field[ii] = new_field(qsoFormFieldDesc[ii].height,
-                                 qsoFormFieldDesc[ii].width,
-                                 qsoFormFieldDesc[ii].top,
-                                 qsoFormFieldDesc[ii].left,
-                                 0, 0);
-    set_field_opts(co->field[ii], qsoFormFieldDesc[ii].options);
-    set_field_back(co->field[ii], qsoFormFieldDesc[ii].bgcolor);
-    set_field_fore(co->field[ii], qsoFormFieldDesc[ii].fgcolor);
+    co->field[ii] = new_field(qso_form_field[ii].height,
+                              qso_form_field[ii].width,
+                              qso_form_field[ii].top,
+                              qso_form_field[ii].left,
+                              0, 0);
+    set_field_opts(co->field[ii], qso_form_field[ii].options);
+    set_field_back(co->field[ii], qso_form_field[ii].bgcolor);
+    set_field_fore(co->field[ii], qso_form_field[ii].fgcolor);
   }
 
   co->field[QFFT_MAX] = NULL;
@@ -119,7 +123,7 @@ void initQsoFormComponent(qsoFormComponent *co) {
 
   wattron(co->window, COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR) | A_BOLD);
   for (ii = 0; ii < QFFT_MAX; ii++) {
-    mvwprintw(co->window, 1, qsoFormFieldDesc[ii].left + 1, qsoFormFieldDesc[ii].label);
+    mvwprintw(co->window, 1, qso_form_field[ii].left + 1, qso_form_field[ii].label);
   }
   wattroff(co->window, COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR) | A_BOLD);
 }
@@ -141,6 +145,12 @@ void refreshQsoFormComponent(qsoFormComponent *co) {
 
 
 void processQsoFormComponentInput(qsoFormComponent *co, int ch) {
+  time_t rawtime;
+  struct tm *timeinfo;
+
+  time(&rawtime);
+  timeinfo = localtime(&rawtime);
+
   switch (ch) {
     case KEY_RIGHT:
     case '\t':
@@ -154,6 +164,30 @@ void processQsoFormComponentInput(qsoFormComponent *co, int ch) {
     case KEY_BACKSPACE:
       form_driver(co->form, REQ_DEL_PREV);
       form_driver(co->form, REQ_END_LINE);
+      break;
+    case 10:
+      // TODO(JS): this should eventually go to the respective forms
+      form_driver(co->form, REQ_VALIDATION);
+
+      addQsoListComponentItem(qso_list, timeinfo,
+                              field_buffer(co->field[QFFT_MODE], 0),
+                              field_buffer(co->field[QFFT_BAND], 0),
+                              field_buffer(co->field[QFFT_CALLSIGN], 0),
+                              field_buffer(co->field[QFFT_RSTSENT], 0),
+                              field_buffer(co->field[QFFT_RSTRCVD], 0));
+
+      form_driver(co->form, REQ_LAST_FIELD);
+      form_driver(co->form, REQ_CLR_FIELD);
+      form_driver(co->form, REQ_PREV_FIELD);
+      form_driver(co->form, REQ_CLR_FIELD);
+      form_driver(co->form, REQ_PREV_FIELD);
+      form_driver(co->form, REQ_CLR_FIELD);
+      form_driver(co->form, REQ_PREV_FIELD);
+      form_driver(co->form, REQ_CLR_FIELD);
+      form_driver(co->form, REQ_PREV_FIELD);
+      form_driver(co->form, REQ_CLR_FIELD);
+      form_driver(co->form, REQ_PREV_FIELD);
+      form_driver(co->form, REQ_CLR_FIELD);
       break;
     default:
       form_driver(co->form, ch);

--- a/src/qsoform.h
+++ b/src/qsoform.h
@@ -28,7 +28,7 @@ typedef struct qsoFormField_s {
 } qsoFormField;
 
 
-typedef struct qsoForm_s {
+typedef struct qsoFormComponent_s {
   FIELD  *field[QFFT_MAX + 1];
   FORM   *form;
   WINDOW *window;
@@ -36,7 +36,8 @@ typedef struct qsoForm_s {
 } qsoFormComponent;
 
 
-extern qsoFormField qsoFormFieldDesc[QFFT_MAX];
+extern qsoFormField qso_form_field[QFFT_MAX];
+extern qsoFormComponent *qso_form;
 
 
 qsoFormComponent *newQsoFormComponent(void);

--- a/src/qsolist.c
+++ b/src/qsolist.c
@@ -1,10 +1,14 @@
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <panel.h>
 
 #include "config.h"
 #include "qsolist.h"
+
+
+qsoListComponent *qso_list;
 
 
 qsoListComponent *newQsoListComponent(void) {
@@ -40,4 +44,17 @@ void freeQsoListComponent(qsoListComponent *co) {
   delwin(co->window);
 
   free(co);
+}
+
+
+void addQsoListComponentItem(qsoListComponent *co, struct tm *timeinfo,
+                             const char *mode, const char *band,
+                             const char *callsign, const char *rstsent,
+                             const char *rstrcvd) {
+  char timestr[32] = { 0 };
+
+  strftime(timestr, sizeof(timestr) - 1, "%Y %b %d %H:%M ", timeinfo);
+
+  sprintf(co->buffer, "%s%s%s%s%s%s%s\n", co->buffer, timestr, mode, band,
+          callsign, rstsent, rstrcvd);
 }

--- a/src/qsolist.h
+++ b/src/qsolist.h
@@ -12,10 +12,18 @@ typedef struct qsoListComponent_s {
 } qsoListComponent;
 
 
+extern qsoListComponent *qso_list;
+
+
 qsoListComponent *newQsoListComponent(void);
 void initQsoListComponent(qsoListComponent *co);
 void refreshQsoListComponent(qsoListComponent *co);
 void freeQsoListComponent(qsoListComponent *co);
+
+void addQsoListComponentItem(qsoListComponent *co, struct tm *timeinfo,
+                             const char *mode, const char *band,
+                             const char *callsign, const char *rstsent,
+                             const char *rstrcvd);
 
 
 #endif // __qsolist_h__


### PR DESCRIPTION
This is the followup to #16 and refactors adding to qso list into `addQsoListComponentItem` function.

This also refactors `qsoListComponent` and `qsoFormComponent` into singletons, without refactoring the implementation. This means that if for whatever reason a custom/separate instance of the component is needed - it can be created without much complications.