### PR TITLE
Utilize full height of the terminal

### DIFF
--- a/src/qsoform.c
+++ b/src/qsoform.c
@@ -17,8 +17,8 @@ qsoFormField qso_form_field[QFFT_MAX] = {
     .height = 1,
     .top = 1,
     .left = 1,
-    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
-    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .bgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
     .options = O_PUBLIC | O_STATIC | O_VISIBLE,
   },
   {
@@ -28,8 +28,8 @@ qsoFormField qso_form_field[QFFT_MAX] = {
     .height = 1,
     .top = 1,
     .left = 20,
-    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
-    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .bgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
     .options = O_PUBLIC | O_STATIC | O_VISIBLE,
   },
   {
@@ -39,8 +39,8 @@ qsoFormField qso_form_field[QFFT_MAX] = {
     .height = 1,
     .top = 1,
     .left = 26,
-    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
-    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .bgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
     .options = O_PUBLIC | O_STATIC | O_VISIBLE,
   },
   {
@@ -50,8 +50,8 @@ qsoFormField qso_form_field[QFFT_MAX] = {
     .height = 1,
     .top = 1,
     .left = 35,
-    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
-    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .bgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
     .options = O_PUBLIC | O_STATIC | O_VISIBLE | O_EDIT | O_ACTIVE,
   },
   {
@@ -61,8 +61,8 @@ qsoFormField qso_form_field[QFFT_MAX] = {
     .height = 1,
     .top = 1,
     .left = 46,
-    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
-    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .bgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
     .options = O_PUBLIC | O_STATIC | O_VISIBLE | O_EDIT | O_ACTIVE,
   },
   {
@@ -72,8 +72,8 @@ qsoFormField qso_form_field[QFFT_MAX] = {
     .height = 1,
     .top = 1,
     .left = 51,
-    .bgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
-    .fgcolor = COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR),
+    .bgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
+    .fgcolor = COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR),
     .options = O_PUBLIC | O_STATIC | O_VISIBLE | O_EDIT | O_ACTIVE,
   },
 };
@@ -90,7 +90,7 @@ qsoFormComponent *newQsoFormComponent(void) {
 void initQsoFormComponent(qsoFormComponent *co) {
   int cols, rows, ii;
 
-  init_pair(QSOFORMPANEL_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
+  init_pair(QSOFORMCOMPONENT_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
 
   for (ii = 0; ii < QFFT_MAX; ii++) {
     co->field[ii] = new_field(qso_form_field[ii].height,
@@ -109,7 +109,7 @@ void initQsoFormComponent(qsoFormComponent *co) {
 
   scale_form(co->form, &rows, &cols);
 
-  co->window = newwin(rows + 2, COLS, 20, 0);
+  co->window = newwin(rows + 2, COLS, LINES - rows - 2, 0);
   keypad(co->window, TRUE);
 
   box(co->window, 0, 0);
@@ -121,11 +121,11 @@ void initQsoFormComponent(qsoFormComponent *co) {
 
   post_form(co->form);
 
-  wattron(co->window, COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR) | A_BOLD);
+  wattron(co->window, COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR) | A_BOLD);
   for (ii = 0; ii < QFFT_MAX; ii++) {
     mvwprintw(co->window, 1, qso_form_field[ii].left + 1, qso_form_field[ii].label);
   }
-  wattroff(co->window, COLOR_PAIR(QSOFORMPANEL_COLOR_PAIR) | A_BOLD);
+  wattroff(co->window, COLOR_PAIR(QSOFORMCOMPONENT_COLOR_PAIR) | A_BOLD);
 }
 
 

--- a/src/qsoform.h
+++ b/src/qsoform.h
@@ -1,7 +1,10 @@
 #ifndef __qsoform_h__
 #define __qsoform_h__
 
-#define QSOFORMPANEL_COLOR_PAIR 1
+#include <form.h>
+
+
+#define QSOFORMCOMPONENT_COLOR_PAIR 1
 
 
 typedef enum qsoFormFieldType_e {

--- a/src/qsolist.c
+++ b/src/qsolist.c
@@ -5,6 +5,7 @@
 #include <panel.h>
 
 #include "config.h"
+#include "qsoform.h"
 #include "qsolist.h"
 
 
@@ -13,26 +14,37 @@ qsoListComponent *qso_list;
 
 qsoListComponent *newQsoListComponent(void) {
   qsoListComponent *co = (qsoListComponent *)malloc(sizeof(qsoListComponent));
-  memset((void *)co->buffer, 0, 2048);
+  memset((void *)co->buffer, 0, 4096);
 
   return co;
 }
 
 
 void initQsoListComponent(qsoListComponent *co) {
-  co->window = newwin(20, COLS, 0, 0);
+  int ii;
+
+  init_pair(QSOLISTCOMPONENT_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
+
+  co->window = newwin(LINES - 4, COLS, 0, 0);
   keypad(co->window, TRUE);
 
   co->panel = new_panel(co->window);
   box(co->window, 0, 0);
-  co->pad = newpad(18, COLS - 2);
+
+  wattron(co->window, COLOR_PAIR(QSOLISTCOMPONENT_COLOR_PAIR) | A_BOLD);
+  for (ii = 0; ii < QFFT_MAX; ii++) {
+    mvwprintw(co->window, 1, qso_form_field[ii].left + 1, qso_form_field[ii].label);
+  }
+  wattroff(co->window, COLOR_PAIR(QSOLISTCOMPONENT_COLOR_PAIR) | A_BOLD);
+
+  co->pad = newpad(LINES - 7, COLS - 3);
   touchwin(co->window);
 }
 
 
 void refreshQsoListComponent(qsoListComponent *co) {
   mvwprintw(co->pad, 0, 0, co->buffer);
-  prefresh(co->pad, 0, 0, 1, 1, 18, COLS - 2);
+  prefresh(co->pad, 0, 0, 2, 2, LINES - 6, COLS - 3);
 }
 
 
@@ -55,6 +67,6 @@ void addQsoListComponentItem(qsoListComponent *co, struct tm *timeinfo,
 
   strftime(timestr, sizeof(timestr) - 1, "%Y %b %d %H:%M ", timeinfo);
 
-  sprintf(co->buffer, "%s%s%s%s%s%s%s\n", co->buffer, timestr, mode, band,
+  sprintf(co->buffer, "%s%s %s %s %s %s %s\n", co->buffer, timestr, mode, band,
           callsign, rstsent, rstrcvd);
 }

--- a/src/qsolist.h
+++ b/src/qsolist.h
@@ -1,14 +1,14 @@
 #ifndef __qsolist_h__
 #define __qsolist_h__
 
-#define QSOFORMPANEL_COLOR_PAIR 1
+#define QSOLISTCOMPONENT_COLOR_PAIR 2
 
 
 typedef struct qsoListComponent_s {
   PANEL  *panel;
   WINDOW *window;
   WINDOW *pad;
-  char    buffer[2048];
+  char    buffer[4096];
 } qsoListComponent;
 
 


### PR DESCRIPTION
## Description

Part of #1 

Make the QSO list and form utilize the full height of the terminal instead of using just top 25 lines.

## Motivation and Context

There are no other features implemented yet that would need the space so this just makes the app look more serious.

## How Has This Been Tested?

Ran `src/lhl` and filled in qso list with random data and verified nothing goes out of bounds.

## Screenshots (if appropriate):

![screenshot from 2018-12-24 13-08-03](https://user-images.githubusercontent.com/141768/50400329-d194b100-077d-11e9-997f-c8255fba9571.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated **HISTORY** document.
  - [ ] I have referenced pull request and/or issue next to the change.
- [ ] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
  - [ ] I have added tests to cover my changes.
