### PR TITLE
Use ncurses pad to enable qsolist scrolling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ int main(void)
       break;
     default:
       processQsoFormComponentInput(qso_form, ch);
+      processQsoListComponentInput(qso_list, ch);
       break;
     }
 

--- a/src/qsolist.c
+++ b/src/qsolist.c
@@ -14,7 +14,6 @@ qsoListComponent *qso_list;
 
 qsoListComponent *newQsoListComponent(void) {
   qsoListComponent *co = (qsoListComponent *)malloc(sizeof(qsoListComponent));
-  memset((void *)co->buffer, 0, 4096);
 
   return co;
 }
@@ -22,6 +21,9 @@ qsoListComponent *newQsoListComponent(void) {
 
 void initQsoListComponent(qsoListComponent *co) {
   int ii;
+
+  co->cursor = 0;
+  co->numitems = 0;
 
   init_pair(QSOLISTCOMPONENT_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
 
@@ -43,17 +45,58 @@ void initQsoListComponent(qsoListComponent *co) {
 
 
 void refreshQsoListComponent(qsoListComponent *co) {
-  mvwprintw(co->pad, 0, 0, co->buffer);
-  prefresh(co->pad, 0, 0, 2, 2, LINES - 6, COLS - 3);
+  int ii, idx = 0, totalsize = 0;
+  char *buffer;
+
+  for (ii = 0; ii < co->numitems; ii++) {
+    totalsize += co->item[ii].length + 1;
+  }
+
+  buffer = malloc(sizeof(char) * totalsize + 2);
+  memset(buffer, 0, totalsize + 2);
+
+  for (ii = 0; ii < co->numitems; ii++) {
+    memcpy(&buffer[idx], co->item[ii].buffer, co->item[ii].length);
+    idx += co->item[ii].length;
+    buffer[idx] = '\n';
+    idx++;
+  }
+
+  mvwprintw(co->pad, 0, 0, buffer);
+  prefresh(co->pad, co->cursor, 0, 2, 2, LINES - 6, COLS - 3);
+
+  free(buffer);
+}
+
+
+void processQsoListComponentInput(qsoListComponent *co, int ch) {
+  switch (ch) {
+  case KEY_UP:
+    co->cursor--;
+    if (co->cursor < 0) co->cursor = 0;
+    break;
+  case KEY_DOWN:
+    co->cursor++;
+    if (co->cursor >= co->numitems) co->cursor = co->numitems;
+    break;
+  }
 }
 
 
 void freeQsoListComponent(qsoListComponent *co) {
+  int ii;
+
   delwin(co->pad);
 
   del_panel(co->panel);
 
   delwin(co->window);
+
+  for (ii = 0; ii < co->numitems; ii++) {
+    free(co->item[ii].buffer);
+  }
+
+  free(co->item);
 
   free(co);
 }
@@ -63,10 +106,17 @@ void addQsoListComponentItem(qsoListComponent *co, struct tm *timeinfo,
                              const char *mode, const char *band,
                              const char *callsign, const char *rstsent,
                              const char *rstrcvd) {
-  char timestr[32] = { 0 };
+  co->item = realloc(co->item, sizeof(qsoListItem) * (co->numitems + 1));
 
+  char timestr[32] = { 0 };
   strftime(timestr, sizeof(timestr) - 1, "%Y %b %d %H:%M ", timeinfo);
 
-  sprintf(co->buffer, "%s%s %s %s %s %s %s\n", co->buffer, timestr, mode, band,
-          callsign, rstsent, rstrcvd);
+  co->item[co->numitems].buffer = malloc(sizeof(char) * (COLS - 3));
+  memset(co->item[co->numitems].buffer, 0, sizeof(char) * (COLS - 3));
+  snprintf(co->item[co->numitems].buffer, COLS,
+           "%s %s %s %s %s %s",
+           timestr, mode, band, callsign, rstsent, rstrcvd);
+  co->item[co->numitems].length = strlen(co->item[co->numitems].buffer);
+
+  co->numitems++;
 }

--- a/src/qsolist.h
+++ b/src/qsolist.h
@@ -4,11 +4,19 @@
 #define QSOLISTCOMPONENT_COLOR_PAIR 2
 
 
+typedef struct qsoListItem_s {
+  int   length;
+  char *buffer;
+} qsoListItem;
+
+
 typedef struct qsoListComponent_s {
-  PANEL  *panel;
-  WINDOW *window;
-  WINDOW *pad;
-  char    buffer[4096];
+  PANEL       *panel;
+  WINDOW      *window;
+  WINDOW      *pad;
+  int          cursor;
+  int          numitems;
+  qsoListItem *item;
 } qsoListComponent;
 
 
@@ -18,6 +26,7 @@ extern qsoListComponent *qso_list;
 qsoListComponent *newQsoListComponent(void);
 void initQsoListComponent(qsoListComponent *co);
 void refreshQsoListComponent(qsoListComponent *co);
+void processQsoListComponentInput(qsoListComponent *co, int ch);
 void freeQsoListComponent(qsoListComponent *co);
 
 void addQsoListComponentItem(qsoListComponent *co, struct tm *timeinfo,


### PR DESCRIPTION
## Description
Part of #1. Allow scroll up and down of the qso list.

## Motivation and Context
This is required to have more than a couple of tens of qsos and be able to scroll back and forth with them.

## How Has This Been Tested?
Added about 60 qsos and scrolled up and down.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated **HISTORY** document.
  - [ ] I have referenced pull request and/or issue next to the change.
- [ ] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
  - [ ] I have added tests to cover my changes.
