### PR TITLE
Fix memset of qsolist buffer

### DIFF
--- a/src/qsolist.c
+++ b/src/qsolist.c
@@ -57,7 +57,7 @@ void refreshQsoListComponent(qsoListComponent *co) {
   }
 
   buffer = malloc(sizeof(char) * totalsize + 2);
-  memset(buffer, 0, totalsize + 2);
+  memset(buffer, 0, sizeof(char) * totalsize + 2);
   ptr = buffer;
 
   for (ii = 0; ii < co->numitems; ii++) {


### PR DESCRIPTION
## Description
Accidentally missed the `sizeof(char)` in `memset` call. This is potentially harmless, but still - inconsistent.

## Motivation and Context
Maybe in some universe where `char` is not a single byte (AFAIK none such exists) - it could lead in not clearing up of the whole buffer.

## How Has This Been Tested?
Ran `src/lhl` and interacted with UI.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated **HISTORY** document.
  - [ ] I have referenced pull request and/or issue next to the change.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
  - [ ] I have added tests to cover my changes.
