### PR TITLE
Add sqlite3 as a required dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ compiler:
 - clang
 - gcc
 before_script:
+- sudo apt-get update
+- sudo apt-get install libsqlite3-dev
 - autoreconf -i
 script:
 - ./configure && make

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An attempt at writing a modern terminal ham radio logging software for Linux fro
 - `ncurses`
 - `autoconf`
 - `automake`
+- `libsqlite3-dev`
 
 # Compile & Run
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ if test x$HAVE_CURS != xyes; then
   AC_MSG_ERROR([Linux Ham Log requires ncurses library to compile.])
 fi
 
-AX_LIB_SQLITE3(3.20)
+AX_LIB_SQLITE3()
 if test "x$success" != "xyes"; then
   AC_MSG_ERROR([Linux Ham Log requires SQLite3 to compile.])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,11 @@ if test x$HAVE_CURS != xyes; then
   AC_MSG_ERROR([Linux Ham Log requires ncurses library to compile.])
 fi
 
+AX_LIB_SQLITE3(3.20)
+if test "x$success" != "xyes"; then
+  AC_MSG_ERROR([Linux Ham Log requires SQLite3 to compile.])
+fi
+
 AC_CONFIG_FILES([
   Makefile
   src/Makefile

--- a/m4/ax_lib_sqlite4.m4
+++ b/m4/ax_lib_sqlite4.m4
@@ -1,0 +1,156 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_lib_sqlite3.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_LIB_SQLITE3([MINIMUM-VERSION])
+#
+# DESCRIPTION
+#
+#   Test for the SQLite 3 library of a particular version (or newer)
+#
+#   This macro takes only one optional argument, required version of SQLite
+#   3 library. If required version is not passed, 3.0.0 is used in the test
+#   of existence of SQLite 3.
+#
+#   If no installation prefix to the installed SQLite library is given the
+#   macro searches under /usr, /usr/local, and /opt.
+#
+#   This macro calls:
+#
+#     AC_SUBST(SQLITE3_CFLAGS)
+#     AC_SUBST(SQLITE3_LDFLAGS)
+#     AC_SUBST(SQLITE3_VERSION)
+#
+#   And sets:
+#
+#     HAVE_SQLITE3
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Mateusz Loskot <mateusz@loskot.net>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 18
+
+AC_DEFUN([AX_LIB_SQLITE3],
+[
+    AC_ARG_WITH([sqlite3],
+        AS_HELP_STRING(
+            [--with-sqlite3=@<:@ARG@:>@],
+            [use SQLite 3 library @<:@default=yes@:>@, optionally specify the prefix for sqlite3 library]
+        ),
+        [
+        if test "$withval" = "no"; then
+            WANT_SQLITE3="no"
+        elif test "$withval" = "yes"; then
+            WANT_SQLITE3="yes"
+            ac_sqlite3_path=""
+        else
+            WANT_SQLITE3="yes"
+            ac_sqlite3_path="$withval"
+        fi
+        ],
+        [WANT_SQLITE3="yes"]
+    )
+
+    SQLITE3_CFLAGS=""
+    SQLITE3_LDFLAGS=""
+    SQLITE3_VERSION=""
+
+    if test "x$WANT_SQLITE3" = "xyes"; then
+
+        ac_sqlite3_header="sqlite3.h"
+
+        sqlite3_version_req=ifelse([$1], [], [3.0.0], [$1])
+        sqlite3_version_req_shorten=`expr $sqlite3_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
+        sqlite3_version_req_major=`expr $sqlite3_version_req : '\([[0-9]]*\)'`
+        sqlite3_version_req_minor=`expr $sqlite3_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
+        sqlite3_version_req_micro=`expr $sqlite3_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+        if test "x$sqlite3_version_req_micro" = "x" ; then
+            sqlite3_version_req_micro="0"
+        fi
+
+        sqlite3_version_req_number=`expr $sqlite3_version_req_major \* 1000000 \
+                                   \+ $sqlite3_version_req_minor \* 1000 \
+                                   \+ $sqlite3_version_req_micro`
+
+        AC_MSG_CHECKING([for SQLite3 library >= $sqlite3_version_req])
+
+        if test "$ac_sqlite3_path" != ""; then
+            ac_sqlite3_ldflags="-L$ac_sqlite3_path/lib"
+            ac_sqlite3_cppflags="-I$ac_sqlite3_path/include"
+        else
+            for ac_sqlite3_path_tmp in /usr /usr/local /opt ; do
+                if test -f "$ac_sqlite3_path_tmp/include/$ac_sqlite3_header" \
+                    && test -r "$ac_sqlite3_path_tmp/include/$ac_sqlite3_header"; then
+                    ac_sqlite3_path=$ac_sqlite3_path_tmp
+                    ac_sqlite3_cppflags="-I$ac_sqlite3_path_tmp/include"
+                    ac_sqlite3_ldflags="-L$ac_sqlite3_path_tmp/lib"
+                    break;
+                fi
+            done
+        fi
+
+        ac_sqlite3_ldflags="$ac_sqlite3_ldflags -lsqlite3"
+
+        saved_CPPFLAGS="$CPPFLAGS"
+        CPPFLAGS="$CPPFLAGS $ac_sqlite3_cppflags"
+
+        AC_LANG_PUSH(C)
+        AC_COMPILE_IFELSE(
+            [
+            AC_LANG_PROGRAM([[@%:@include <sqlite3.h>]],
+                [[
+#if (SQLITE_VERSION_NUMBER >= $sqlite3_version_req_number)
+/* Everything is okay */
+#else
+#  error SQLite version is too old
+#endif
+                ]]
+            )
+            ],
+            [
+            AC_MSG_RESULT([yes])
+            success="yes"
+            ],
+            [
+            AC_MSG_RESULT([not found])
+            success="no"
+            ]
+        )
+        AC_LANG_POP(C)
+
+        CPPFLAGS="$saved_CPPFLAGS"
+
+        if test "$success" = "yes"; then
+
+            SQLITE3_CFLAGS="$ac_sqlite3_cppflags"
+            SQLITE3_LDFLAGS="$ac_sqlite3_ldflags"
+
+            ac_sqlite3_header_path="$ac_sqlite3_path/include/$ac_sqlite3_header"
+
+            dnl Retrieve SQLite release version
+            if test "x$ac_sqlite3_header_path" != "x"; then
+                ac_sqlite3_version=`cat $ac_sqlite3_header_path \
+                    | grep '#define.*SQLITE_VERSION.*\"' | sed -e 's/.* "//' \
+                        | sed -e 's/"//'`
+                if test $ac_sqlite3_version != ""; then
+                    SQLITE3_VERSION=$ac_sqlite3_version
+                else
+                    AC_MSG_WARN([Cannot find SQLITE_VERSION macro in sqlite3.h header to retrieve SQLite version!])
+                fi
+            fi
+
+            AC_SUBST(SQLITE3_CFLAGS)
+            AC_SUBST(SQLITE3_LDFLAGS)
+            AC_SUBST(SQLITE3_VERSION)
+            AC_DEFINE([HAVE_SQLITE3], [], [Have the SQLITE3 library])
+        fi
+    fi
+])


### PR DESCRIPTION
## Description
Adds an sqlite3 library and headers check to `configure` script.

## Motivation and Context
Part of #4 it will be used to save log data later on.

## How Has This Been Tested?
Ran `./configure` with and without `libsqlite3-dev` installed and observed expected behaviour.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] I have updated **HISTORY** document.
  - [ ] I have referenced pull request and/or issue next to the change.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
  - [ ] I have added tests to cover my changes.
